### PR TITLE
Fix invalid JSON in package.json for Vercel build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nuxtjs/i18n": "10.4.0",
-    "nuxt": "4.4.8",
+    "nuxt": "4.4.8"
   },
   "devDependencies": {
     "typescript": "6.0.3"


### PR DESCRIPTION
Remove trailing comma after the last dependency entry.